### PR TITLE
Remove unused variable from wstring deserializer

### DIFF
--- a/c_plus_plus_serializer.h
+++ b/c_plus_plus_serializer.h
@@ -98,7 +98,6 @@ static inline std::istream& operator>>(std::istream& in, Bits<std::wstring &> v)
     my_size_t sz = 0;
     in >> bits(sz);
     if (in && sz) {
-        std::vector<wchar_t> tmp(sz);
         while (sz--) {
             wchar_t tmp;
             in >> bits(tmp);


### PR DESCRIPTION
Remove unused variable from wstring deserializer

This fixes a compiler error because the unused variable `std::vector<wchar_t> tmp(sz)` is shadowed by `wchar_t tmp`